### PR TITLE
Readme and Templates improvement

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,3 +13,10 @@ Currently running at https://nimble.directory
 - [ ] Pkg metadata signing
 - [x] Pkgs RSS / web feed
 - [ ] Search selectors
+
+
+.Use:
+- For Development, Copy and edit `conf.json.example` to `conf.json`.
+- Download the Nims packages.json to projects root folder: https://raw.githubusercontent.com/nim-lang/packages/master/packages.json
+- Execute `nim c -r -d:systemd package_directory.nim`.
+- Open on the web browser http://localhost:5000/search

--- a/package_directory.nim
+++ b/package_directory.nim
@@ -483,7 +483,7 @@ proc github_trending_packages(request: Request, pkgs: Pkgs): seq[JsonNode] =
   result = @[]
   let pkgs_list = fetch_github_repository_stats(
     sorting="updated", pagenum=1, limit=20,
-    initial_date=getGmTime(getTime() - 14.days)
+    initial_date=utc(getTime() - 14.days)
   )
   var website_to_name = initTable[string, string]()
   for it in pkgs.values:

--- a/templates/about.tmpl
+++ b/templates/about.tmpl
@@ -25,9 +25,9 @@
 [![Build Status](https://nimble.directory/ci/badges/jester/nimdevel/docstatus.svg)](https://nimble.directory/ci/badges/jester/nimdevel/doc_build_output.html)
       </code>
     </pre>
-    Add your own packages <a href="https://github.com/nim-lang/packages/">here</a>
+    <a href="https://github.com/nim-lang/packages/">Add your own packages.</a>
 
-    Contribute to the service <a href="https://github.com/FedericoCeratto/nim-package-directory" class="btn btn-link">here</a>
+    <a href="https://github.com/FedericoCeratto/nim-package-directory">Contribute to this service.</a>
     </p>
   </div>
 </div>

--- a/templates/doc_files_list.tmpl
+++ b/templates/doc_files_list.tmpl
@@ -1,7 +1,7 @@
 #? stdtmpl | standard
 #proc generate_doc_files_list_page(pkg_name: string, m: PkgDocMetadata): string =
 #  result = ""
-    <h3>Doc files for <a href="/pkg/${pkg_name}">${pkg_name}</a></h3>
+    <h4>Hosted Documentation for <a href="/pkg/${pkg_name}">${pkg_name}</a></h4>
     <ul>
 #    for fn in m.fnames:
     <li><a href="/docs/${pkg_name}/${fn}">${fn}</a></li>

--- a/templates/home.tmpl
+++ b/templates/home.tmpl
@@ -4,7 +4,7 @@
 <div class="columns">
   <div class="column col-12 search-box">
     <form action="/search" method="GET" role="search" class="input-group">
-      <input class="form-input" name="query" placeholder="Find Nimble packages..." type="text" value="$value">
+      <input class="form-input" name="query" placeholder="Find Nimble packages..." type="search" value="$value" minlength="1" autofocus required >
       <button type="submit" class="btn btn-primary input-group-btn">
         <i class="fa fa-search"></i> Search
       </button>

--- a/templates/pkg.tmpl
+++ b/templates/pkg.tmpl
@@ -32,7 +32,9 @@
       </div>
       <div class="tile-content">
         <div class="tile-title">
-          <tt>$$ nimble install ${pkg["name"].str}</tt>
+          <tt>
+            <input onClick="this.select();" value="nimble install ${pkg["name"].str}" readonly />
+          </tt>
         </div>
         <div class="tile-subtitle">
           Need help? Read <a href="https://github.com/nim-lang/nimble#creating-packages">Nimble</a>


### PR DESCRIPTION
Tiny improvements on Readme and Templates.

- Added a basic usage info for development on the Readme.
- Changed some "Click Here" links for proper wording (Google "Click Here links UX").
- Changed some slang-like wording for proper wording (hard to understand for non-native speakers).
- Changed the Search input `type=text` for `type=search` https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search
- Changed the `p` with the `nimble install` command for input `type=text` with `readonly` with select all on click.

The `nimble install` command was getting cut off when the package name is long:

![nimbl](https://user-images.githubusercontent.com/1189414/40287833-8b53fb6c-5c86-11e8-95a7-408c06215710.jpg)
:smile_cat: 
