### PR TITLE
Template Improvements.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,5 +18,5 @@ Currently running at https://nimble.directory
 .Use:
 - For Development, Copy and edit `conf.json.example` to `conf.json`.
 - Download the Nims packages.json to projects root folder: https://raw.githubusercontent.com/nim-lang/packages/master/packages.json
-- Execute `nim c -r -d:systemd package_directory.nim`.
+- Execute `nim c -r package_directory.nim`.
 - Open on the web browser http://localhost:5000/search

--- a/conf.json.example
+++ b/conf.json.example
@@ -1,7 +1,7 @@
 {
   "github_token": "",
   "log_fname": "pkgs.log",
-  "packages_list_fname": "packages.json"
+  "packages_list_fname": "packages.json",
   "public_baseurl": "https://nimble.directory",
   "port": 5000,
   "tmp_nimble_root_dir": "/var/lib/nim_package_directory/cache"

--- a/templates/doc_files_list.tmpl
+++ b/templates/doc_files_list.tmpl
@@ -1,9 +1,16 @@
 #? stdtmpl | standard
 #proc generate_doc_files_list_page(pkg_name: string, m: PkgDocMetadata): string =
 #  result = ""
-    <h4>Hosted Documentation for <a href="/pkg/${pkg_name}">${pkg_name}</a></h4>
-    <ul>
+<div class="panel">
+  <div class="panel-header">
+    <div class="panel-title">
+      <h4>Hosted Documentation for <a href="/pkg/${pkg_name}">${pkg_name}</a></h4>
+    </div>
+  </div>
+  <ul>
 #    for fn in m.fnames:
-    <li><a href="/docs/${pkg_name}/${fn}">${fn}</a></li>
+    <li><a href="/docs/${pkg_name}/${fn}">${fn.replace(".html", "")}</a></li>
 #    end for
-    </ul>
+  </ul>
+  <small> ${m.fnames.len} documented files.</small><br>
+</div>

--- a/templates/pkg.tmpl
+++ b/templates/pkg.tmpl
@@ -60,7 +60,10 @@
       <div class="tile-content">
         #if pkg["github_versions"].getElems().len > 0:
           Available versions:
-          <b>${pkg["github_versions"].getElems().join(", ")}</b>
+        #  for semver in pkg["github_versions"].getElems():
+            <label class="chip"><b>${semver}</b></label>
+        #  end
+          <br>
         #else:
           No tagged versions available
         #end
@@ -74,20 +77,32 @@
     #     let licns = pkg["license"].str.toLowerAscii.strip
     #     if licns == "mit":
             <a href="https://opensource.org/licenses/MIT">MIT</a>
-    #     elif licns == "apache2":
+    #     elif licns == "apache2" or licns == "apache":
             <a href="https://opensource.org/licenses/Apache-2.0">Apache 2</a>
-    #     elif licns == "bsd2":
+    #     elif licns == "bsd":
+            <a href="https://opensource.org/licenses/BSD-2-Clause">BSD</a>
+    #     elif licns == "bsd2" or licns == "bsd 2-clause":
             <a href="https://opensource.org/licenses/BSD-2-Clause">BSD 2-Clause</a>
-    #     elif licns == "bsd3":
+    #     elif licns == "bsd3" or licns == "bsd 3-clause":
             <a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a>
+    #     elif licns == "gplv2":
+            <a href="https://opensource.org/licenses/GPL-2.0">GPL 2</a>
     #     elif licns == "gplv3":
             <a href="https://opensource.org/licenses/GPL-3.0">GPL 3</a>
     #     elif licns == "gpl":
             <a href="https://opensource.org/licenses/GPL-3.0">GPL</a>
+    #     elif licns == "lgplv2":
+            <a href="https://opensource.org/licenses/LGPL-2.0">LGPL 2</a>
     #     elif licns == "lgplv3":
             <a href="https://opensource.org/licenses/LGPL-3.0">LGPL 3</a>
     #     elif licns == "lgpl":
             <a href="https://opensource.org/licenses/LGPL-3.0">LGPL</a>
+    #     elif licns == "cc0":
+            <a href="https://creativecommons.org/publicdomain/zero/1.0">Creative Commons Zero</a>
+    #     elif licns == "cc" or licns == "cc-by-nc-sa" or licns == "cc-by-nc-nd":
+            <a href="https://creativecommons.org/licenses">Creative Commons</a>
+    #     elif licns == "wtfpl":
+            <a href="http://www.wtfpl.net">WTFPL</a>
     #     else:
             ${pkg["license"].str}
         </div>

--- a/templates/pkg.tmpl
+++ b/templates/pkg.tmpl
@@ -33,7 +33,8 @@
       <div class="tile-content">
         <div class="tile-title">
           <tt>
-            <input onClick="this.select();" value="nimble install ${pkg["name"].str}" readonly />
+            <input id="cmd" onClick="this.select();" value="nimble install ${pkg["name"].str}" readonly />
+            <a title="Copy" onClick="document.querySelector('#cmd').select();document.execCommand('copy');"><i class="fa fa-copy"></i></a>
           </tt>
         </div>
         <div class="tile-subtitle">

--- a/templates/pkg.tmpl
+++ b/templates/pkg.tmpl
@@ -70,7 +70,26 @@
     <div class="tile tile-centered divided">
       <div class="tile-content">
         <div class="tile-title">
-          License: ${pkg["license"].str}
+          License:
+    #     let licns = pkg["license"].str.toLowerAscii.strip
+    #     if licns == "mit":
+            <a href="https://opensource.org/licenses/MIT">MIT</a>
+    #     elif licns == "apache2":
+            <a href="https://opensource.org/licenses/Apache-2.0">Apache 2</a>
+    #     elif licns == "bsd2":
+            <a href="https://opensource.org/licenses/BSD-2-Clause">BSD 2-Clause</a>
+    #     elif licns == "bsd3":
+            <a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause</a>
+    #     elif licns == "gplv3":
+            <a href="https://opensource.org/licenses/GPL-3.0">GPL 3</a>
+    #     elif licns == "gpl":
+            <a href="https://opensource.org/licenses/GPL-3.0">GPL</a>
+    #     elif licns == "lgplv3":
+            <a href="https://opensource.org/licenses/LGPL-3.0">LGPL 3</a>
+    #     elif licns == "lgpl":
+            <a href="https://opensource.org/licenses/LGPL-3.0">LGPL</a>
+    #     else:
+            ${pkg["license"].str}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Multiple tiny Templates Improvements.

- Add a "Copy to Clipboard" on nimble install command, just like GitHubs.
- On the Hosted Documentation page make layout follow the rest of the site instead of full blank page.
- Add Links to popular open source licences on package page automatically.
- Update Readme since `-d:systemd` on the execution command is not required anymore.
- Fix `conf.json.example` config to be actually Valid JSON (missing 1 comma).

:smile_cat: 
