### PR TITLE
Fixes #14 -- RSS Feed Validation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,6 +17,10 @@ Currently running at https://nimble.directory
 - [x] Package count at /api/v1/package_count
 - [ ] Pkg metadata signing
 
+=======
+.Prerequisites:
+- ZMQ on your platform
+
 .Use:
 - For Development, Copy and edit `conf.json.example` to `conf.json`.
 - Download the Nims packages.json to projects root folder: https://raw.githubusercontent.com/nim-lang/packages/master/packages.json

--- a/package_directory.nim
+++ b/package_directory.nim
@@ -1304,7 +1304,7 @@ router mainRouter:
         desc: pkg["description"].str,
         url: item_url,
         guid: item_url,
-        pubdate: $item.first_seen_time
+        pubdate: $item.first_seen_time.utc.format("ddd, dd MMM yyyy hh:mm:ss zz")
       )
       rss_items.add i
 
@@ -1312,8 +1312,8 @@ router mainRouter:
       title="Nim packages",
       desc="New and updated Nim packages",
       url=url,
-      build_date="",
-      pub_date="",
+      build_date= getTime().utc.format("ddd, dd MMM yyyy hh:mm:ss zz"),
+      pub_date= getTime().utc.format("ddd, dd MMM yyyy hh:mm:ss zz"),
       ttl=3600,
       rss_items
     )

--- a/templates/rss.tmpl
+++ b/templates/rss.tmpl
@@ -2,7 +2,7 @@
 #proc generate_rss_feed(title="", desc="", url="", buildDate="", pubDate="", ttl=3600, items:seq[RssItem]): string =
 #  result = ""
 <?xml version="1.0" encoding="UTF-8" ?>
-<rss version="2.0">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>${title}</title>
     <description>${desc}</description>
@@ -20,6 +20,5 @@
      <pubDate>${item.pubDate}</pubDate>
     </item>
     # end for
-
   </channel>
 </rss>


### PR DESCRIPTION
Hi!

I suspect that the RSS feed issue was due to the formatting of the feed, and pubdate not being in the proper format.

This request makes the RSS feed valid.

We _may_ need to re-order the RSS feed items, but there is nothing in the spec that I found that mandates that, but it depends on the client implementation and how it parses the feed.