### PR TITLE
Better doc gen

### DIFF
--- a/package_directory.nim
+++ b/package_directory.nim
@@ -909,7 +909,8 @@ proc generate_jsondoc(pname: string) {.async.} =
       input_fnames.add fname
 
   for fname in input_fnames:
-    let desc = "nim jsondoc $#" % fname
+    let args = @["jsondoc", "--project", "--docCmd:skip", fname]
+    let desc = "nim " & args.join(" ")
     log_debug "running " & desc
     let run_dir = fname.splitPath.head
     let po = await run_process2(
@@ -918,7 +919,7 @@ proc generate_jsondoc(pname: string) {.async.} =
       run_dir,
       10,
       true,
-      @["jsondoc", fname],
+      args,
     )
     let success = (po.exit_code == 0)
     if success:
@@ -1035,7 +1036,12 @@ proc fetch_and_build_pkg_if_needed_wrapped(pname: string, force_rebuild = false)
     pkgs_doc_files[pname].doc_build_status
   )
 
-  pkgs_doc_files[pname].version = await pname.get_version()
+  if pkgs[pname].hasKey("github_latest_version"):
+    pkgs_doc_files[pname].version = pkgs[pname][
+        "github_latest_version"].str.strip
+  else:
+    log_debug "FIXME github_latest_version"
+    pkgs_doc_files[pname].version = "?"
 
   let fn = package_parent_dir(pname) & "/nimpkgdir.json"
   save_pkg_metadata(pkgs_doc_files[pname], fn)

--- a/templates/empty.tmpl
+++ b/templates/empty.tmpl
@@ -1,12 +1,6 @@
 #? stdtmpl | standard
 #proc empty_page*(req: Request, content: string): string =
 #  result = ""
-<head>
-	<link rel="stylesheet" href="${req.makeUri("css/nimdoc.out.css", false)}">
-</head>
-
-
-    
 
 <div class="content">
 

--- a/templates/pkg.tmpl
+++ b/templates/pkg.tmpl
@@ -113,6 +113,15 @@
           <a href="/docs/${pname}"><button class="btn pkg-btn">Hosted docs</button></a>
         #end if
 
+
+        <form action="/searchitem_pkg" method="GET" role="search" class="input-group" id="searchitem">
+          <input id="search-pkg" name="query" type="search"  placeholder="Search Symbols in ${pname}" value="" minlength="1" autofocus required>
+          <input name="pkg_name" type="hidden" value="${pname}">
+        </form>
+        <div class="search-content">
+            <div id="searchitem_result"></div>
+        </div>
+
     </div>
   </div>
 </div>
@@ -139,13 +148,17 @@
           });
           setInterval(reload_rebuildbtn, 5000);
           reload_rebuildbtn();
+
+          $$("#searchitem").submit(function(event) {
+            var data = $$("#searchitem :input").serializeArray();
+            $$("#searchitem_result").load("/searchitem_pkg", data);
+            event.preventDefault();
+          });
         </script>
-
       </div>
     </div>
       </div>
     </div>
-
   </div>
 </div>
 

--- a/templates/pkg.tmpl
+++ b/templates/pkg.tmpl
@@ -112,14 +112,7 @@
         #if url.startswith("https://github.com/") or url.startswith("http://github.com/") or url.startswith("git"):
           <a href="/docs/${pname}"><button class="btn pkg-btn">Hosted docs</button></a>
         #end if
-    
-        <form action="/searchitem_pkg" method="GET" role="search" class="input-group" id="searchitem">
-          <input id="search-pkg" name="query" type="search"  placeholder="Search Symbols in ${pname}" value="" minlength="1" autofocus required>
-          <input name="pkg_name" type="hidden" value="${pname}">
-        </form>
-        <div class="search-content">
-            <div id="searchitem_result"></div>
-        </div>
+
     </div>
   </div>
 </div>
@@ -150,15 +143,6 @@
 
       </div>
     </div>
-
-  
-        <script>
-          $$("#searchitem").submit(function(event) {
-            var data = $$("#searchitem :input").serializeArray();
-            $$("#searchitem_result").load("/searchitem_pkg", data);
-            event.preventDefault();
-          });
-        </script>
       </div>
     </div>
 

--- a/templates/pkg1.tmpl
+++ b/templates/pkg1.tmpl
@@ -103,6 +103,15 @@
         <a href="/docs/${pname}"><button class="btn pkg-btn">Hosted docs</button></a>
       #end if
     
+      <form action="/searchitem_pkg" method="GET" role="search" class="input-group" id="searchitem">
+        <input id="search-pkg" name="query" type="search"  placeholder="Search Symbols in ${pname}" value="" minlength="1" autofocus required>
+        <input name="pkg_name" type="hidden" value="${pname}">
+      </form>
+
+
+      <div class="search-content">
+        <div id="searchitem_result">
+      </div>
       </div>
     </div>
   </div>

--- a/templates/pkg1.tmpl
+++ b/templates/pkg1.tmpl
@@ -103,15 +103,6 @@
         <a href="/docs/${pname}"><button class="btn pkg-btn">Hosted docs</button></a>
       #end if
     
-      <form action="/searchitem_pkg" method="GET" role="search" class="input-group" id="searchitem">
-        <input id="search-pkg" name="query" type="search"  placeholder="Search Symbols in ${pname}" value="" minlength="1" autofocus required>
-        <input name="pkg_name" type="hidden" value="${pname}">
-      </form>
-      
-            
-      <div class="search-content">
-        <div id="searchitem_result">
-      </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Should close #46

Makes a few changes to how doc generation / hosting is done

- Doc generation is done for the whole project
- `runnableExamples` don't run so compile time is speed up
- User gets sent directly to `theindex.html` when they click hosted docs

Still bit work in progress