### PR TITLE
Fix layout for mobile phone and tablet sizes.

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -381,5 +381,4 @@ footer a {
 
 @media (max-width: 992px) {
   #art { display: none; }
-  #meta-section { display: none; }
 }

--- a/templates/base.tmpl
+++ b/templates/base.tmpl
@@ -16,7 +16,7 @@
 </head>
 <body>
 <nav class="navbar navbar-expand-lg fixed-top py-3">
-  <div class="container">
+  <div class="container-fluid container-lg">
     <a href="/" class="logo fw-500 display-1 text-black text-decoration-none navbar-brand"></a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse">
       <span class="navbar-toggler-icon"></span>

--- a/templates/pkg.tmpl
+++ b/templates/pkg.tmpl
@@ -4,12 +4,12 @@
 
 # let package_name = pkg["name"].str
 
-<div class="container">
-  <div class="container pt-10">
+<div class="container-fluid container-lg">
+  <div class="pt-10">
     <h3 class="mb-3 fw-bold display-6 pt-4">${package_name}</h3>
-    <p class="tags">
+    <p>
       #for tag in pkg["tags"]:
-      <span class="tag">
+      <span class="badge p-0">
         <a href="/search?query=$tag.str"><button class="btn-tag pkg-btn-tag">
         $tag.str
         </button></a>
@@ -25,16 +25,9 @@
     <small style="font-size: 0.8rem;">Need help? Read <a href="https://github.com/nim-lang/nimble#creating-packages">Nimble</a></small>
   </div>
 
-  <div class="container row pt-4" id="pkg-content">
-    <div class="col-8 box rounded p-3" id="readme-section">
-      #if pkg.has_key("github_readme"):
-        ${pkg["github_readme"].str}
-      #else:
-        <p class="no-readme"><i>The package README is not present or from an unsupported forge.</i></p>
-      #end
-    </div>
-    <div class="col-3" id="meta-section">
-      <div class="container box rounded p-3">
+  <div class="row pt-4 g-3" id="pkg-content">
+    <div class="col-lg-4 order-lg-2" id="meta-section">
+      <div class="box rounded p-3">
         #if pkg.has_key("github_owner"):
           <p class="pkg-author"><strong>Author:</strong>
             <a href="https://github.com/${pkg["github_owner"].str}">${pkg["github_owner"].str}</a>
@@ -94,6 +87,15 @@
         #if pkg.has_key("doc"):
         <p> <a href="${pkg["doc"].str}">Docs</a> </p>
         #end if
+      </div>
+    </div>
+    <div class="col-lg-8" id="readme-section">
+      <div class="box rounded p-3">
+        #if pkg.has_key("github_readme"):
+          ${pkg["github_readme"].str}
+        #else:
+          <p class="no-readme"><i>The package README is not present or from an unsupported forge.</i></p>
+        #end
       </div>
     </div>
   </div>


### PR DESCRIPTION
This pull request includes a few fixes:

1. The package metadata column is no longer hidden at small sizes. It is now the first column at small sizes and moves to the second column at large sizes. 
2. It was necessary to remove some extra "container" classes, as well as to add a container div to the readme section to fix spacing issues that become apparent when stacking the columns at small sizes.
3. Fixes the tags layout at mobile sizes. The tags now have vertical spaces between them when viewed on a phone.

## screenshots

### mobile phone
<img width="1326" alt="Screenshot 2024-07-08 at 12 07 13 AM" src="https://github.com/FedericoCeratto/nim-package-directory/assets/7064600/1ad54193-318d-4ae2-941f-131330928d1d">

### small tablet
<img width="1326" alt="Screenshot 2024-07-08 at 12 07 01 AM" src="https://github.com/FedericoCeratto/nim-package-directory/assets/7064600/a37f9da8-c5e4-4ac3-b445-bc6744f17619">

### large tablet
<img width="1334" alt="Screenshot 2024-07-08 at 12 06 38 AM" src="https://github.com/FedericoCeratto/nim-package-directory/assets/7064600/95809189-56a5-411d-9ffd-9d1695fa022e">

### 4k monitor
<img width="2542" alt="Screenshot 2024-07-08 at 12 09 44 AM" src="https://github.com/FedericoCeratto/nim-package-directory/assets/7064600/aa92b908-63ae-4ae8-8579-d0432eac27ec">
